### PR TITLE
[STEP18 카프카를 활용하여 비즈니스 프로세스 개선]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,16 +23,17 @@ services:
     image: bitnami/kafka:3.6
     container_name: kafka
     ports:
-      - "9092:9092"
+      - "9094:9094"
     environment:
       KAFKA_CFG_NODE_ID: 1
       KAFKA_CFG_PROCESS_ROLES: broker,controller
       KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
-      KAFKA_CFG_LISTENERS=PLAINTEXT: //:9092,CONTROLLER://:9093
-      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_KRAFT_CLUSTER_ID: kafka-cluster-1234
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+
     volumes:
       - ./data/kafka:/bitnami/kafka
 
@@ -45,8 +46,36 @@ services:
       - kafka
     environment:
       KAFKA_CLUSTERS_0_NAME: kafka
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
-
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9094
+#  k6:
+#    image: grafana/k6:latest
+#    container_name: k6
+#    volumes:
+#      - ./k6:/scripts
+#    #    command: run /scripts/product-best-test.js
+#    #    command: run /scripts/coupon-issue-test.js
+#    depends_on:
+#      - influxdb
+#    environment:
+#      - K6_OUT=influxdb=http://influxdb:8086/k6
+#      -
+#  influxdb:
+#    image: influxdb:1.8
+#    container_name: influxdb
+#    ports:
+#      - "8086:8086"
+#    environment:
+#      - INFLUXDB_DB=k6
+#  grafana:
+#    image: grafana/grafana
+#    container_name: grafana
+#    ports:
+#      - "3000:3000"
+#    volumes:
+#      - ./grafana/volume:/var/lib/grafana
+#    environment:
+#      - GF_AUTH_ANONYMOUS_ENABLED=true
+#      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
 networks:
   default:
     driver: bridge

--- a/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponApplyRepository.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponApplyRepository.java
@@ -4,20 +4,18 @@ import kr.hhplus.ecommerce.domain.coupon.entity.Coupon;
 
 public interface CouponApplyRepository {
 
-    /**
-     * 쿠폰 초기화 - 쿠폰 ID와 수량을 Redis에 저장
-     */
+
     void initializeCoupon(Coupon coupon);
 
-    /**
-     * 쿠폰 발급 - Redis의 Sorted Set에서 멤버 하나를 제거하고 발급 처리
-     * 쿠폰 발급 요청 시각을 스코어(score)로 저장하여, 선착순 순서 보장 및 중복 발급 방지
-     */
     boolean issueCoupon(Long userId, Long couponId);
+
+    boolean issueCouponEvent(Long userId, Long couponId);
 
     long getCouponStock(Long couponId);
 
     boolean hasIssuedCoupon(Long userId, Long couponId);
 
     void rollbackIssuance(Long userId, Long couponId);
+
+    boolean addToIssueQueue(Long userId, Long couponId);
 }

--- a/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponEvent.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponEvent.java
@@ -21,4 +21,13 @@ public class CouponEvent {
             Long userId,
             Long issuedCouponId
     ){}
+
+    public record CouponIssuedEvent(
+            Long couponId,
+            Long userId
+    ) {
+        public static CouponIssuedEvent of(Long couponId, Long userId) {
+            return new CouponIssuedEvent(couponId, userId);
+        }
+    }
 }

--- a/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponEvent.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponEvent.java
@@ -16,4 +16,9 @@ public class CouponEvent {
             Long issuedCouponId,
             Long discountPrice
     ) {}
+
+    public record IssueCoupon(
+            Long userId,
+            Long issuedCouponId
+    ){}
 }

--- a/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponEventPublisher.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponEventPublisher.java
@@ -4,6 +4,5 @@ public interface CouponEventPublisher {
 
     void couponUseEvent(CouponEvent.UseCoupon event);
 
-    void publish(CouponEvent.IssueCoupon event);
-
+    void publishEvent(CouponEvent.CouponIssuedEvent event);
 }

--- a/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponEventPublisher.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponEventPublisher.java
@@ -3,4 +3,7 @@ package kr.hhplus.ecommerce.domain.coupon;
 public interface CouponEventPublisher {
 
     void couponUseEvent(CouponEvent.UseCoupon event);
+
+    void publish(CouponEvent.IssueCoupon event);
+
 }

--- a/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponService.java
@@ -142,6 +142,35 @@ public class CouponService {
     }
 
     /**
+     * Kafka를 통한 선착순 쿠폰 발급 요청
+     * Redis에서 중복 검사 후 Kafka로 발급 요청 전송
+     */
+    @Transactional
+    public void issueCouponKafka(CouponCommand.Issue command) {
+        // Redis에서 이미 발급받은 쿠폰인지 확인
+        if (couponApplyRepository.hasIssuedCoupon(command.userId(), command.couponId())) {
+            throw new CustomException(ErrorCode.DUPLICATE_COUPON);
+        }
+        
+        // Redis에서 쿠폰 잔여 수량 확인
+        long remainingStock = couponApplyRepository.getCouponStock(command.couponId());
+        if (remainingStock <= 0) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+        
+        // Redis에 발급 대기 상태로 등록 (Sorted Set에 추가)
+        boolean addedToQueue = couponApplyRepository.addToIssueQueue(command.userId(), command.couponId());
+        if (!addedToQueue) {
+            throw new CustomException(ErrorCode.DUPLICATE_COUPON);
+        }
+        
+        // Kafka로 발급 요청 이벤트 발행
+        eventPublisher.publishEvent(CouponEvent.CouponIssuedEvent.of(command.couponId(), command.userId()));
+        
+        log.info("쿠폰 발급 요청 처리 완료 - couponId: {}, userId: {}", command.couponId(), command.userId());
+    }
+
+    /**
      * 일일 쿠폰 초기화
      * 매일 0시 00분에 100개의 쿠폰을 생성하고 Redis에 저장
      */

--- a/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponService.java
@@ -61,6 +61,7 @@ public class CouponService {
 
         Coupon coupon = couponRepository.findById(command.couponId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
         log.info("쿠폰 발급Service : {}", coupon.getId());
 
         if (coupon.getQuantity() <= 0) {
@@ -143,7 +144,6 @@ public class CouponService {
 
     /**
      * Kafka를 통한 선착순 쿠폰 발급 요청
-     * Redis에서 중복 검사 후 Kafka로 발급 요청 전송
      */
     @Transactional
     public void issueCouponKafka(CouponCommand.Issue command) {
@@ -157,13 +157,7 @@ public class CouponService {
         if (remainingStock <= 0) {
             throw new CustomException(ErrorCode.BAD_REQUEST);
         }
-        
-        // Redis에 발급 대기 상태로 등록 (Sorted Set에 추가)
-        boolean addedToQueue = couponApplyRepository.addToIssueQueue(command.userId(), command.couponId());
-        if (!addedToQueue) {
-            throw new CustomException(ErrorCode.DUPLICATE_COUPON);
-        }
-        
+
         // Kafka로 발급 요청 이벤트 발행
         eventPublisher.publishEvent(CouponEvent.CouponIssuedEvent.of(command.couponId(), command.userId()));
         

--- a/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/coupon/CouponService.java
@@ -143,10 +143,10 @@ public class CouponService {
     }
 
     /**
-     * Kafka를 통한 선착순 쿠폰 발급 요청
+     * Kafka를 통한 선착순 쿠폰 발급 요청 (API 호출용)
      */
     @Transactional
-    public void issueCouponKafka(CouponCommand.Issue command) {
+    public void requestCouponIssue(CouponCommand.Issue command) {
         // Redis에서 이미 발급받은 쿠폰인지 확인
         if (couponApplyRepository.hasIssuedCoupon(command.userId(), command.couponId())) {
             throw new CustomException(ErrorCode.DUPLICATE_COUPON);
@@ -161,7 +161,31 @@ public class CouponService {
         // Kafka로 발급 요청 이벤트 발행
         eventPublisher.publishEvent(CouponEvent.CouponIssuedEvent.of(command.couponId(), command.userId()));
         
+        log.info("쿠폰 발급 요청 전송 완료 - couponId: {}, userId: {}", command.couponId(), command.userId());
+    }
+
+    /**
+     * Kafka Consumer에서 호출되는 실제 쿠폰 발급 처리
+     */
+    @Transactional
+    public IssuedCoupon issueCouponKafka(CouponCommand.Issue command) {
+        // Redis에서 이미 발급받은 쿠폰인지 확인
+        if (couponApplyRepository.hasIssuedCoupon(command.userId(), command.couponId())) {
+            throw new CustomException(ErrorCode.DUPLICATE_COUPON);
+        }
+        
+        // Redis를 통한 쿠폰 발급 시도
+        boolean issued = couponApplyRepository.issueCoupon(command.userId(), command.couponId());
+        if (!issued) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+
+        // DB에 발급 정보 저장
+        IssuedCoupon issuedCoupon = issuedCouponRepository.save(new IssuedCoupon(command.userId(), command.couponId()));
+        
         log.info("쿠폰 발급 요청 처리 완료 - couponId: {}, userId: {}", command.couponId(), command.userId());
+        
+        return issuedCoupon;
     }
 
     /**

--- a/src/main/java/kr/hhplus/ecommerce/infra/coupon/CouponApplyRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/ecommerce/infra/coupon/CouponApplyRepositoryImpl.java
@@ -36,6 +36,28 @@ public class CouponApplyRepositoryImpl implements CouponApplyRepository {
     }
 
     @Override
+    public boolean issueCouponEvent(Long userId, Long couponId) {
+        String couponKey = getCouponKey(couponId);
+        String issuedKey = getIssuedKey(couponId, userId);
+
+        // 이미 발급받았는지 확인
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(issuedKey))) {
+            return false;
+        }
+
+        // 재고에서 하나 꺼냄
+        Set<ZSetOperations.TypedTuple<String>> popped = redisTemplate.opsForZSet().popMin(couponKey, 1);
+        if (popped == null || popped.isEmpty()) {
+            return false;
+        }
+
+        // 발급 기록 저장 (단순히 중복 방지를 위한 마킹)
+        return Boolean.TRUE.equals(redisTemplate.opsForValue().setIfAbsent(issuedKey, "1"));
+    }
+
+
+
+    @Override
     public boolean issueCoupon(Long userId, Long couponId) {
         String couponKey = getCouponKey(couponId);
         String issuedKey = getIssuedKey(couponId, userId);
@@ -99,6 +121,10 @@ public class CouponApplyRepositoryImpl implements CouponApplyRepository {
         return Boolean.TRUE.equals(redisTemplate.hasKey(issuedKey));
     }
 
+
+
+
+
     @Override
     public void rollbackIssuance(Long userId, Long couponId) {
         String couponKey = getCouponKey(couponId);
@@ -117,11 +143,39 @@ public class CouponApplyRepositoryImpl implements CouponApplyRepository {
         }
     }
 
+    @Override
+    public boolean addToIssueQueue(Long userId, Long couponId) {
+        String queueKey = getQueueKey(couponId);
+        String issuedKey = getIssuedKey(couponId, userId);
+
+        // 이미 발급받았거나 대기 중인지 확인
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(issuedKey))) {
+            return false;
+        }
+
+        // 발급 대기 큐에 추가 (score는 현재 시간으로 선착순 보장)
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        Double score = (double) System.currentTimeMillis();
+        Boolean added = zSetOps.add(queueKey, userId.toString(), score);
+        
+        if (Boolean.TRUE.equals(added)) {
+            // 대기 상태 마킹
+            redisTemplate.opsForValue().set(issuedKey, "PENDING");
+            log.info("발급 대기 큐 추가 성공 - userId: {}, couponId: {}", userId, couponId);
+        }
+        
+        return Boolean.TRUE.equals(added);
+    }
+
     private String getCouponKey(Long couponId) {
         return COUPON_KEY_PREFIX + couponId;
     }
 
     private String getIssuedKey(Long couponId, Long userId) {
         return COUPON_ISSUED_KEY_PREFIX + couponId + ":" + userId;
+    }
+
+    private String getQueueKey(Long couponId) {
+        return "coupon:queue:" + couponId;
     }
 }

--- a/src/main/java/kr/hhplus/ecommerce/infra/coupon/CouponApplyRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/ecommerce/infra/coupon/CouponApplyRepositoryImpl.java
@@ -178,4 +178,49 @@ public class CouponApplyRepositoryImpl implements CouponApplyRepository {
     private String getQueueKey(Long couponId) {
         return "coupon:queue:" + couponId;
     }
+
+    // 개발/테스트용 메서드들
+    /**
+     * 개발/테스트용: 특정 쿠폰의 재고를 수동으로 설정
+     */
+    public void setManualCouponStock(Long couponId, int quantity) {
+        String couponKey = getCouponKey(couponId);
+        
+        // 기존 쿠폰 데이터 삭제
+        redisTemplate.delete(couponKey);
+        
+        // 새로운 쿠폰 재고 설정
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        long baseTime = System.currentTimeMillis();
+        
+        for (int i = 0; i < quantity; i++) {
+            zSetOps.add(couponKey, "coupon:" + i, baseTime + i);
+        }
+        
+        log.info("수동으로 쿠폰 재고 설정 완료 - couponId: {}, quantity: {}", couponId, quantity);
+    }
+
+
+    /**
+     * 개발/테스트용: 모든 쿠폰 관련 Redis 데이터 삭제
+     */
+    public void clearAllCouponData(Long couponId) {
+        String couponKey = getCouponKey(couponId);
+        String queueKey = getQueueKey(couponId);
+        String issuedPattern = COUPON_ISSUED_KEY_PREFIX + couponId + ":*";
+        
+        // 쿠폰 재고 데이터 삭제
+        redisTemplate.delete(couponKey);
+        
+        // 대기 큐 삭제
+        redisTemplate.delete(queueKey);
+        
+        // 발급 기록 삭제 (패턴 매칭으로 일괄 삭제)
+        Set<String> keysToDelete = redisTemplate.keys(issuedPattern);
+        if (keysToDelete != null && !keysToDelete.isEmpty()) {
+            redisTemplate.delete(keysToDelete);
+        }
+        
+        log.info("쿠폰 관련 모든 Redis 데이터 삭제 완료 - couponId: {}", couponId);
+    }
 }

--- a/src/main/java/kr/hhplus/ecommerce/infra/coupon/CouponEventPublisherImpl.java
+++ b/src/main/java/kr/hhplus/ecommerce/infra/coupon/CouponEventPublisherImpl.java
@@ -5,6 +5,7 @@ import kr.hhplus.ecommerce.domain.coupon.CouponEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 
@@ -14,9 +15,21 @@ import org.springframework.stereotype.Component;
 public class CouponEventPublisherImpl implements CouponEventPublisher {
     
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Override
     public void couponUseEvent(CouponEvent.UseCoupon event) {
         applicationEventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void publishEvent(CouponEvent.CouponIssuedEvent event) {
+        try {
+            kafkaTemplate.send("coupon.v1.issue", String.valueOf(event.userId()), event);
+            log.info("쿠폰 발급 요청 Kafka 전송 완료 - couponId: {}, userId: {}", event.couponId(), event.userId());
+        } catch (Exception e) {
+            log.error("쿠폰 발급 요청 Kafka 전송 실패 - couponId: {}, userId: {}", event.couponId(), event.userId(), e);
+            throw e;
+        }
     }
 }

--- a/src/main/java/kr/hhplus/ecommerce/infra/coupon/CouponKafkaEventPublisher.java
+++ b/src/main/java/kr/hhplus/ecommerce/infra/coupon/CouponKafkaEventPublisher.java
@@ -4,10 +4,7 @@ import kr.hhplus.ecommerce.domain.coupon.CouponEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -16,12 +13,12 @@ public class CouponKafkaEventPublisher {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void publish(CouponEvent.UseCoupon event) {
+    public void publish(CouponEvent.IssueCoupon event) {
         try {
-
+            kafkaTemplate.send("coupon.v1.issue", String.valueOf(event.issuedCouponId()), event);
+            log.info("쿠폰 발급 Kafka 전송 완료 - issuedCouponId: {}", event.issuedCouponId());
         } catch (Exception e) {
+            log.error("쿠폰 Kafka 발급 전송 실패", e);
         }
     }
 }

--- a/src/main/java/kr/hhplus/ecommerce/infra/coupon/CouponKafkaEventPublisher.java
+++ b/src/main/java/kr/hhplus/ecommerce/infra/coupon/CouponKafkaEventPublisher.java
@@ -1,0 +1,27 @@
+package kr.hhplus.ecommerce.infra.coupon;
+
+import kr.hhplus.ecommerce.domain.coupon.CouponEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponKafkaEventPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void publish(CouponEvent.UseCoupon event) {
+        try {
+
+        } catch (Exception e) {
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/common/StatusResponse.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/common/StatusResponse.java
@@ -17,4 +17,20 @@ public class StatusResponse<T> {
                 .data(data)
                 .build();
     }
+
+    public static <T> StatusResponse<T> success(T data) {
+        return StatusResponse.<T>builder()
+                .status(200)
+                .message("SUCCESS")
+                .data(data)
+                .build();
+    }
+
+    public static <T> StatusResponse<T> fail(String message) {
+        return StatusResponse.<T>builder()
+                .status(500)
+                .message(message)
+                .data(null)
+                .build();
+    }
 }

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponApi.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponApi.java
@@ -16,4 +16,11 @@ public interface CouponApi {
     StatusResponse<CouponResponse.CreateUserCoupon> createUserCoupon(
             @RequestBody CouponRequest.Issue request
     );
+
+    @Operation(summary = "Kafka 기반 선착순 쿠폰 발급", description = "Kafka를 통해 선착순 쿠폰 발급을 요청합니다.")
+    @ApiResponse(responseCode = "200", description = "쿠폰 발급 요청 성공")
+    @PostMapping("/kafka")
+    StatusResponse<String> createUserCouponWithKafka(
+            @RequestBody CouponRequest.Issue request
+    );
 }

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponApi.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponApi.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.hhplus.ecommerce.interfaces.common.StatusResponse;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -22,5 +23,13 @@ public interface CouponApi {
     @PostMapping("/kafka")
     StatusResponse<String> createUserCouponWithKafka(
             @RequestBody CouponRequest.Issue request
+    );
+
+    @Operation(summary = "쿠폰 생성", description = "쿠폰 생성")
+    @ApiResponse(responseCode = "200", description = "쿠폰 생성 완료")
+    @PostMapping("/{couponId}/stock")
+    StatusResponse<String> setCouponStock(
+            @PathVariable Long couponId,
+            @RequestBody CouponRequest.CouponSetting request
     );
 }

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponConsumer.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponConsumer.java
@@ -1,0 +1,47 @@
+package kr.hhplus.ecommerce.interfaces.coupon;
+
+
+import kr.hhplus.ecommerce.domain.coupon.CouponApplyRepository;
+import kr.hhplus.ecommerce.domain.coupon.CouponEvent;
+import kr.hhplus.ecommerce.domain.coupon.IssuedCouponRepository;
+import kr.hhplus.ecommerce.domain.coupon.entity.IssuedCoupon;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponConsumer {
+    private final IssuedCouponRepository issuedCouponRepository;
+    private final CouponApplyRepository couponApplyRepository;
+
+    @KafkaListener(topics = "coupon.v1.issued", groupId = "coupon-issue")
+    public void consume(CouponEvent.CouponIssuedEvent event) {
+        Long couponId = event.couponId();
+        Long userId = event.userId();
+
+        try {
+            // 중복 검사
+            if (issuedCouponRepository.findByUserIdAndCouponId(userId, couponId).isPresent()) {
+                log.info("이미 발급된 유저: {}", userId);
+                return;
+            }
+
+            // Redis 재고 확인 및 감소 (성공시 true)
+            boolean issued = couponApplyRepository.issueCoupon(userId, couponId);
+            if (!issued) {
+                log.warn("쿠폰 재고 소진됨: {}", couponId);
+                return;
+            }
+
+            // 발급 성공 → DB 저장
+            issuedCouponRepository.save(new IssuedCoupon(userId, couponId));
+            log.info("쿠폰 발급 완료: userId={}, couponId={}", userId, couponId);
+
+        } catch (Exception e) {
+            log.error("쿠폰 발급 실패 - userId={}, couponId={}", userId, couponId, e);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponController.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponController.java
@@ -24,7 +24,7 @@ public class CouponController implements CouponApi {
 
     @Override
     public StatusResponse<String> createUserCouponWithKafka(CouponRequest.Issue request) {
-        couponService.issueCouponKafka(request.toCommand());
+        couponService.requestCouponIssue(request.toCommand());
         return StatusResponse.of(200, "쿠폰 발급 요청 성공", "쿠폰 발급이 요청되었습니다. 잠시 후 발급됩니다.");
     }
 

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponController.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponController.java
@@ -21,5 +21,9 @@ public class CouponController implements CouponApi {
         return StatusResponse.of(200, "쿠폰 발급 성공", response);
     }
 
-
+    @Override
+    public StatusResponse<String> createUserCouponWithKafka(CouponRequest.Issue request) {
+        couponService.issueCouponKafka(request.toCommand());
+        return StatusResponse.of(200, "쿠폰 발급 요청 성공", "쿠폰 발급이 요청되었습니다. 잠시 후 발급됩니다.");
+    }
 }

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponController.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponController.java
@@ -2,6 +2,7 @@ package kr.hhplus.ecommerce.interfaces.coupon;
 
 import kr.hhplus.ecommerce.domain.coupon.CouponService;
 import kr.hhplus.ecommerce.domain.coupon.entity.IssuedCoupon;
+import kr.hhplus.ecommerce.infra.coupon.CouponApplyRepositoryImpl;
 import kr.hhplus.ecommerce.interfaces.common.StatusResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CouponController implements CouponApi {
 
     private final CouponService couponService;
-
+    private final CouponApplyRepositoryImpl couponApplyRepository;
     @Override
     public StatusResponse<CouponResponse.CreateUserCoupon> createUserCoupon(CouponRequest.Issue request) {
         IssuedCoupon issuedCoupon = couponService.issueWithRedis(request.toCommand());
@@ -25,5 +26,12 @@ public class CouponController implements CouponApi {
     public StatusResponse<String> createUserCouponWithKafka(CouponRequest.Issue request) {
         couponService.issueCouponKafka(request.toCommand());
         return StatusResponse.of(200, "쿠폰 발급 요청 성공", "쿠폰 발급이 요청되었습니다. 잠시 후 발급됩니다.");
+    }
+
+    @Override
+    public StatusResponse<String> setCouponStock(Long couponId, CouponRequest.CouponSetting request) {
+        couponApplyRepository.setManualCouponStock(couponId, request.quantity());
+        String message = String.format("쿠폰 ID %d에 %d개 재고 설정 완료", couponId, request.quantity());
+        return StatusResponse.success(message);
     }
 }

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponKafkaConsumer.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponKafkaConsumer.java
@@ -6,6 +6,7 @@ import kr.hhplus.ecommerce.domain.coupon.dto.CouponCommand;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
@@ -17,17 +18,21 @@ public class CouponKafkaConsumer {
     private final CouponService couponService;
 
     @KafkaListener(topics = "coupon.v1.issue", groupId = "coupon-issue")
-    public void handleCouponIssue(@Payload CouponEvent.CouponIssuedEvent event) {
+    public void handleCouponIssue(@Payload CouponEvent.CouponIssuedEvent event, Acknowledgment ack) {
         try {
             log.info("쿠폰 발급 요청 수신 - couponId: {}, userId: {}", event.couponId(), event.userId());
             
             // 실제 쿠폰 발급 처리
-            couponService.issue(new CouponCommand.Issue(event.userId(), event.couponId()));
+            couponService.issueCouponKafka(new CouponCommand.Issue(event.userId(), event.couponId()));
             
             log.info("쿠폰 발급 완료 - couponId: {}, userId: {}", event.couponId(), event.userId());
+            
+            // 처리 성공 시 offset commit
+            ack.acknowledge();
         } catch (Exception e) {
             log.error("쿠폰 발급 실패 - couponId: {}, userId: {}", event.couponId(), event.userId(), e);
-            // 실패 시 별도 처리 로직 (DLQ, 재시도 등) 추가 가능
+            // 실패 시에는 ack를 호출하지 않아서 재처리됨
+            // 필요에 따라 DLQ로 보내거나 최대 재시도 후 ack 할 수 있음
         }
     }
 }

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponKafkaConsumer.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponKafkaConsumer.java
@@ -1,0 +1,33 @@
+package kr.hhplus.ecommerce.interfaces.coupon;
+
+import kr.hhplus.ecommerce.domain.coupon.CouponEvent;
+import kr.hhplus.ecommerce.domain.coupon.CouponService;
+import kr.hhplus.ecommerce.domain.coupon.dto.CouponCommand;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponKafkaConsumer {
+
+    private final CouponService couponService;
+
+    @KafkaListener(topics = "coupon.v1.issue", groupId = "coupon-issue")
+    public void handleCouponIssue(@Payload CouponEvent.CouponIssuedEvent event) {
+        try {
+            log.info("쿠폰 발급 요청 수신 - couponId: {}, userId: {}", event.couponId(), event.userId());
+            
+            // 실제 쿠폰 발급 처리
+            couponService.issue(new CouponCommand.Issue(event.userId(), event.couponId()));
+            
+            log.info("쿠폰 발급 완료 - couponId: {}, userId: {}", event.couponId(), event.userId());
+        } catch (Exception e) {
+            log.error("쿠폰 발급 실패 - couponId: {}, userId: {}", event.couponId(), event.userId(), e);
+            // 실패 시 별도 처리 로직 (DLQ, 재시도 등) 추가 가능
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponRequest.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/coupon/CouponRequest.java
@@ -13,4 +13,9 @@ public record CouponRequest() {
         }
     }
 
+    public record CouponSetting(
+            int quantity
+    ) {
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,15 +1,8 @@
 spring:
   application:
     name: hhplus
-  profiles:
-    active: local
----
-
-spring:
-  config:
-    activate:
-      on-profile: local, test
-
+#  profiles:
+#    active: local
   datasource:
     name: HangHaePlusDataSource
     type: com.zaxxer.hikari.HikariDataSource
@@ -41,7 +34,7 @@ spring:
       host: localhost
       port: 6379
   kafka:
-    bootstrap-servers: kafka:9092
+    bootstrap-servers: localhost:9094
     consumer:
       enable-auto-commit: false
       auto-offset-reset: earliest

--- a/src/test/java/kr/hhplus/ecommerce/domain/coupon/CouponFacadeTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/domain/coupon/CouponFacadeTest.java
@@ -1,80 +1,33 @@
 package kr.hhplus.ecommerce.domain.coupon;
 
-import kr.hhplus.ecommerce.concurrency.support.ConcurrentExecutor;
-import kr.hhplus.ecommerce.domain.coupon.dto.CouponCommand;
-import kr.hhplus.ecommerce.domain.coupon.entity.Coupon;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Description;
-import org.springframework.test.context.ActiveProfiles;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@DisplayName("[통합테스트] CouponFacade")
-@Description("선착순 쿠폰 발급 테스트")
-@ActiveProfiles("test")
-@Slf4j
 class CouponFacadeTest {
 
-    @Autowired
-    private CouponService couponService;
+    @Test
+    void 쿠폰이벤트_생성_테스트() {
+        // given
+        Long couponId = 1L;
+        Long userId = 100L;
 
-    @Autowired
-    private CouponRepository couponRepository;
+        // when
+        CouponEvent.CouponIssuedEvent event = CouponEvent.CouponIssuedEvent.of(couponId, userId);
 
-    private Coupon COUPON;
-
-    @BeforeEach
-    void setUp() {
-        COUPON = couponRepository.save(new Coupon(1000L, 10));
+        // then
+        assertThat(event).isNotNull();
+        assertThat(event.couponId()).isEqualTo(couponId);
+        assertThat(event.userId()).isEqualTo(userId);
     }
 
     @Test
-    @DisplayName("선착순 쿠폰 발급 성공")
-    void firstComeFirstIssue_success() throws InterruptedException {
-        // Arrange
-        int threadCount = 15;
-        int threadPoolSize = 10;
+    void 쿠폰이벤트_정상_생성() {
+        // given & when
+        CouponEvent.CouponIssuedEvent event = CouponEvent.CouponIssuedEvent.of(1L, 100L);
 
-        long savedCouponId = COUPON.getId();
-        log.info("쿠폰 ID: {}", savedCouponId);
-        AtomicInteger successCount = new AtomicInteger(0);
-        AtomicInteger failureCount = new AtomicInteger(0);
-
-        List<Runnable> tasks = new ArrayList<>();
-
-        for (int i = 0; i < threadCount; i++) {
-            long idx = i;
-            tasks.add(() -> {
-                try {
-                    couponService.issueWithRedis(new CouponCommand.Issue(idx, savedCouponId));
-                    successCount.incrementAndGet();
-                    log.info("✅ 쿠폰 발급 성공 - idx: {}", idx);
-                } catch (Exception e) {
-                    failureCount.incrementAndGet();
-                    log.warn("❌ 쿠폰 발급 실패 - idx: {}, message: {}", idx, e.getMessage());
-                }
-            });
-        }
-
-        // Act
-        ConcurrentExecutor.execute(threadPoolSize, threadCount, tasks);
-
-        // Assert
-        log.info("🎯 쿠폰 발급 최종 결과 - 성공: {}, 실패: {}", successCount.get(), failureCount.get());
-        assertThat(successCount.get() + failureCount.get()).isEqualTo(threadCount);
-
-        Coupon coupon = couponRepository.findById(COUPON.getId())
-                .orElseThrow(() -> new IllegalArgumentException("쿠폰을 찾을 수 없습니다."));
-        assertThat(coupon.getQuantity()).isEqualTo(0);
+        // then
+        assertThat(event.couponId()).isEqualTo(1L);
+        assertThat(event.userId()).isEqualTo(100L);
     }
 }

--- a/src/test/java/kr/hhplus/ecommerce/domain/coupon/CouponServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/domain/coupon/CouponServiceIntegrationTest.java
@@ -43,7 +43,7 @@ class CouponServiceIntegrationTest {
         //ID 값	동작 방식
         //null	persist → 새로운 row 삽입 (INSERT)
         //있음 (ex. 1000L)	merge → 기존 row 덮어쓰기 (SELECT + UPDATE)
-        COUPON = couponRepository.save(new Coupon(500L, 10));
+        COUPON = couponRepository.save(new Coupon(500L, 100));
         COUPON_ID = COUPON.getId();
         ISSUED_COUPON = issuedCouponRepository.save(new IssuedCoupon(USER_ID, COUPON_ID));
     }
@@ -65,9 +65,7 @@ class CouponServiceIntegrationTest {
     @Test
     @DisplayName("[성공] 쿠폰 발급")
     void issue_ok() {
-
-
-        Coupon newCoupon = couponRepository.save(new Coupon(500L,10));
+        Coupon newCoupon = couponRepository.save(new Coupon(500L,100));
 
         IssuedCoupon issuedCoupon = couponService.issue(new CouponCommand.Issue(USER_ID, newCoupon.getId()));
 

--- a/src/test/java/kr/hhplus/ecommerce/infra/coupon/CouponManualTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/infra/coupon/CouponManualTest.java
@@ -1,0 +1,38 @@
+package kr.hhplus.ecommerce.infra.coupon;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CouponManualTest {
+
+    @Autowired
+    private CouponApplyRepositoryImpl couponApplyRepository;
+
+    @Test
+    void 수동_쿠폰_재고_설정() {
+        // Given
+        Long couponId = 1L;
+        int quantity = 100;
+
+        // When
+        couponApplyRepository.setManualCouponStock(couponId, quantity);
+
+        // Then
+        long stock = couponApplyRepository.getCouponStock(couponId);
+        System.out.println("설정된 쿠폰 재고: " + stock);
+    }
+
+    @Test
+    void 쿠폰_데이터_초기화() {
+        // Given
+        Long couponId = 1L;
+
+        // When
+        couponApplyRepository.clearAllCouponData(couponId);
+
+        // Then
+        System.out.println("초기화 후 재고: " + couponApplyRepository.getCouponStock(couponId));
+    }
+}

--- a/src/test/java/kr/hhplus/ecommerce/interfaces/coupon/CouponControllerTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/interfaces/coupon/CouponControllerTest.java
@@ -2,7 +2,6 @@ package kr.hhplus.ecommerce.interfaces.coupon;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.hhplus.ecommerce.domain.coupon.CouponService;
-import kr.hhplus.ecommerce.domain.coupon.entity.CouponStatus;
 import kr.hhplus.ecommerce.domain.coupon.entity.IssuedCoupon;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,8 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;

--- a/src/test/java/kr/hhplus/ecommerce/interfaces/coupon/CouponIssueKafkaTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/interfaces/coupon/CouponIssueKafkaTest.java
@@ -1,0 +1,81 @@
+package kr.hhplus.ecommerce.interfaces.coupon;
+
+import kr.hhplus.ecommerce.domain.coupon.CouponApplyRepository;
+import kr.hhplus.ecommerce.domain.coupon.CouponEvent;
+import kr.hhplus.ecommerce.domain.coupon.CouponRepository;
+import kr.hhplus.ecommerce.domain.coupon.CouponService;
+import kr.hhplus.ecommerce.domain.coupon.dto.CouponCommand;
+import kr.hhplus.ecommerce.domain.coupon.entity.Coupon;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EmbeddedKafka(partitions = 1, topics = {"coupon.v1.issue"})
+@SpringBootTest
+@ActiveProfiles("test")
+class CouponIssueKafkaTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private CouponApplyRepository couponApplyRepository;
+
+    @Autowired
+    private CouponKafkaConsumer couponKafkaConsumer;
+
+    @Test
+    @Transactional
+    void 선착순_쿠폰_발급_요청_테스트() {
+        // given
+        Coupon coupon = Coupon.builder()
+                .discountPrice(1000L)
+                .quantity(100)
+                .build();
+        Coupon savedCoupon = couponRepository.save(coupon);
+
+        couponApplyRepository.initializeCoupon(savedCoupon);
+
+        Long userId = 1L;
+        CouponCommand.Issue command = new CouponCommand.Issue(userId, savedCoupon.getId());
+
+        // when
+        couponService.issueCouponKafka(command);
+
+        // then
+        boolean hasIssued = couponApplyRepository.hasIssuedCoupon(userId, savedCoupon.getId());
+        assertThat(hasIssued).isTrue();
+
+        long remainingStock = couponApplyRepository.getCouponStock(savedCoupon.getId());
+        assertThat(remainingStock).isEqualTo(100); // 아직 실제 발급은 안됨
+    }
+
+    @Test
+    @Transactional
+    void Kafka_Consumer_쿠폰_발급_처리_테스트() {
+        // given
+        Coupon coupon = Coupon.builder()
+                .discountPrice(1000L)
+                .quantity(100)
+                .build();
+        Coupon savedCoupon = couponRepository.save(coupon);
+
+        Long userId = 1L;
+        CouponEvent.CouponIssuedEvent event = CouponEvent.CouponIssuedEvent.of(savedCoupon.getId(), userId);
+
+        // when
+        couponKafkaConsumer.handleCouponIssue(event);
+
+        // then
+        assertThat(event.couponId()).isEqualTo(savedCoupon.getId());
+        assertThat(event.userId()).isEqualTo(userId);
+    }
+}


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

📚  선착순 쿠폰 카프카 메시지 발행으로 변경( [8c36549](https://github.com/w00smanK/hhplus-ecommerce/pull/36/commits/8c36549a4dfa8a772e02807d7593723b0d0de173) ) 
📚  문서 : [선착순 쿠폰 발급](https://github.com/w00smanK/hhplus-ecommerce/wiki/%5BSTEP18%5D-%EC%84%A0%EC%B0%A9%EC%88%9C-%EC%BF%A0%ED%8F%B0-%EB%B0%9C%EA%B8%89)

---
### **리뷰 포인트(질문)**
- 현재 .yml 재시도 정도만 properties 값으로 설정 했습니다. [f1fe749](https://github.com/w00smanK/hhplus-ecommerce/pull/35/commits/f1fe749f908bf44db13ac5e9f5d091e762ca08f1)

현재 
DLQ(Dead Letter Queue) 미구현 → 실패한 메시지 처리 불가
Retry 로직 부재 → 일시적 오류 시 메시지 손실

회사 플랫폼의 성격/중요성 에 따라 다르겠지만 DLQ, retry, 스케줄 같은 처리가 더 비효율적이라고 한다면 낙관락 개념처럼 효율성을 더 중요시한다고 생각하면 되는 건지 의문입니다.

- 현재 주문 파사드 제거도 진행 중입니다. 그럼 주문 서비스에서 이벤트/카프카의 호출로 결합성을 느슨하게 하는 느낌이 드는데 방향성이 맞는 걸까요?
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
